### PR TITLE
feat: Phase 5 dynamic string resolution via DexTrace

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -151,8 +151,18 @@ logo()
 )
 @click.option(
     "--auto-fix-checksum",
-    help="Automatically repair damaged DEX checksum/signature before analyzing (androguard only)." + 
+    help="Automatically repair damaged DEX checksum/signature before analyzing (androguard only)." +
     "When not provided, Quark will prompt in interactive TTY and skip in non-interactive runs.",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+@click.option(
+    "--dynamic-resolve",
+    "dynamic_resolve",
+    help="Enable dynamic string resolution via DexTrace. Executes encrypted "
+         "string methods at analysis time to recover plaintext for Phase 5 "
+         "keyword matching. Requires: pip install quark-engine[dynamic].",
     is_flag=True,
     default=False,
     show_default=True,
@@ -175,6 +185,7 @@ def entry_point(
     core_library,
     num_of_process,
     auto_fix_checksum,
+    dynamic_resolve,
 ):
     """Quark is an Obfuscation-Neglect Android Malware Scoring System"""
     # Load rules
@@ -238,7 +249,7 @@ def entry_point(
             data = (
                 ParallelQuark(apk_, core_library, num_of_process, auto_fix_checksum)
                 if num_of_process > 1
-                else Quark(apk_, core_library, auto_fix_checksum)
+                else Quark(apk_, core_library, auto_fix_checksum, dynamic_resolve=dynamic_resolve)
             )
             all_labels = {}
             # dictionary containing
@@ -295,7 +306,7 @@ def entry_point(
     data = (
         ParallelQuark(apk[0], core_library, num_of_process, auto_fix_checksum)
         if num_of_process > 1
-        else Quark(apk[0], core_library, auto_fix_checksum)
+        else Quark(apk[0], core_library, auto_fix_checksum, dynamic_resolve=dynamic_resolve)
     )
 
     if label:

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -2,11 +2,16 @@
 # This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
 # See the file 'LICENSE' for copying permission.
 
+import concurrent.futures
+import functools
+import logging
+import time
 from itertools import product
 import operator
 import os
 import re
-from typing import Any, Generator, List, Mapping, Sequence, Tuple
+from pathlib import Path
+from typing import Any, Generator, List, Mapping, Optional, Sequence, Tuple
 
 import numpy as np
 import csv
@@ -39,6 +44,120 @@ from quark.utils.output import (
 )
 from quark.utils.pprint import print_info, print_success, print_warning
 from quark.utils.weight import Weight
+from quark import config
+from quark.utils.logger import defaultHandler
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+log.addHandler(defaultHandler)
+log.disabled = not config.DEBUG
+
+try:
+    from dextrace.api import execute_method as _dextrace_execute  # type: ignore
+    _DEXTRACE_AVAILABLE = True
+except ImportError:
+    _DEXTRACE_AVAILABLE = False
+
+
+@functools.lru_cache(maxsize=512)
+def _dextrace_cached(apk_path: str, sig: str) -> Optional[str]:
+    log.debug("dynamic_resolve: executing %s (cache miss)", sig)
+    result = _dextrace_execute(apk_path, sig, args=[])
+    return str(result) if result is not None else None
+
+
+def _resolveStringCalls(
+    methodCall: MethodCall,
+    apk_path: str,
+    apkinfo=None,
+    parentMethod=None,
+    *,
+    total_timeout_s: float = 10.0,
+) -> Generator[str, None, None]:
+    norm_path = str(Path(apk_path).resolve())
+    deadline = time.monotonic() + total_timeout_s
+    found_any = False
+
+    # Phase 1: prior calls of methodCall (covers cases where the encryption
+    # function is called inside the same frame as the target API call).
+    for priorCall in iteratePriorCalls(methodCall):
+        if time.monotonic() >= deadline:
+            log.debug(
+                "dynamic_resolve: total timeout (%.1fs) reached, remaining candidates skipped",
+                total_timeout_s,
+            )
+            return
+        sig: str = priorCall.method
+        if not sig.endswith(")Ljava/lang/String;"):
+            continue
+        resolved = _dextrace_cached(norm_path, sig)
+        if resolved is not None:
+            log.debug("dynamic_resolve: %s -> %r", sig, resolved)
+            found_any = True
+            yield resolved
+        else:
+            log.debug("dynamic_resolve: %s -> None", sig)
+
+    if found_any or apkinfo is None or parentMethod is None:
+        return
+
+    # Phase 2: the encryption function is called in a CALLER of parentMethod
+    # (the parent method receives the plaintext as a parameter). Scan all
+    # callers of parentMethod and execute any String-returning MethodCalls
+    # that appear in their value graphs.
+    log.debug(
+        "dynamic_resolve: Phase 1 empty — scanning callers of %s", parentMethod
+    )
+    seen_sigs: set = set()
+    try:
+        callers = apkinfo.upperfunc(parentMethod) or set()
+    except Exception:
+        return
+
+    for caller in callers:
+        if time.monotonic() >= deadline:
+            log.debug(
+                "dynamic_resolve: total timeout (%.1fs) reached during caller scan",
+                total_timeout_s,
+            )
+            return
+        try:
+            caller_pyeval = PyEval(apkinfo)
+            for bytecode_obj in apkinfo.get_method_bytecode(caller):
+                instruction = [bytecode_obj.mnemonic]
+                if bytecode_obj.registers is not None:
+                    instruction.extend(bytecode_obj.registers)
+                if bytecode_obj.parameter is not None:
+                    instruction.append(bytecode_obj.parameter)
+                instruction = [str(x) for x in instruction]
+                if instruction[0] in caller_pyeval.eval:
+                    caller_pyeval.eval[instruction[0]](instruction)
+
+            table = caller_pyeval.show_table()
+            for register_list in table.values():
+                for reg_obj in register_list:
+                    for call_node in reg_obj.iterateInvolvedCalls():
+                        sig = call_node.method
+                        if sig in seen_sigs or not sig.endswith(
+                            ")Ljava/lang/String;"
+                        ):
+                            continue
+                        seen_sigs.add(sig)
+                        if time.monotonic() >= deadline:
+                            return
+                        resolved = _dextrace_cached(norm_path, sig)
+                        if resolved is not None:
+                            log.debug(
+                                "dynamic_resolve (caller scan): %s -> %r",
+                                sig,
+                                resolved,
+                            )
+                            yield resolved
+        except Exception as exc:
+            log.debug(
+                "dynamic_resolve: error scanning caller %s: %s", caller, exc
+            )
+
 
 MAX_SEARCH_LAYER = 3
 
@@ -46,12 +165,22 @@ MAX_SEARCH_LAYER = 3
 class Quark:
     """Quark module is used to check quark's five-stage theory"""
 
-    def __init__(self, apk, core_library="androguard", auto_fix_checksum=False):
+    def __init__(self, apk, core_library="androguard", auto_fix_checksum=False, dynamic_resolve=False):
         """
 
         :param apk: the filename of the apk.
+        :param dynamic_resolve: if True, Phase 5 keyword matching will attempt to
+            resolve encrypted strings by executing method calls with DexTrace.
+            Requires the ``dextrace`` package to be installed. Opt-in; default False.
         """
         self.auto_fix_checksum = auto_fix_checksum
+        self._dynamic_resolve = dynamic_resolve
+        if dynamic_resolve and not _DEXTRACE_AVAILABLE:
+            print_warning(
+                "dynamic_resolve=True but the 'dextrace' package is not installed. "
+                "Dynamic string resolution will be skipped. "
+                "Install it with: pip install dextrace"
+            )
 
         core_library = core_library.lower()
         if core_library == "shuriken":
@@ -238,6 +367,7 @@ class Quark:
         firstMethodKeywords: Sequence | None = None,
         secondMethodKeywords: Sequence | None = None,
         regex: bool = False,
+        parentMethod=None,
     ) -> Generator[Tuple[Tuple[MethodCall, MethodCall], List[str]], None, None]:
         """Check the usage of the same parameter between two methods.
 
@@ -249,6 +379,8 @@ class Quark:
         :param secondMethodKeywords: keywords to match for the second method,
         defaults to None
         :param regex: treat keywords as regular expressions, defaults to False
+        :param parentMethod: the method containing firstMethod/secondMethod calls;
+        forwarded to getMatchedKeywords for dynamic caller-frame resolution.
         :yield: a tuple of matched method call pairs and matched keywords
         """
         # Find the first and second method call that share same register
@@ -278,14 +410,16 @@ class Quark:
             if firstMethodKeywords is not None:
                 # Check if arguments of the first call match any keywords.
                 first_matched = self.getMatchedKeywords(
-                    firstCall, firstMethodKeywords, regex=regex
+                    firstCall, firstMethodKeywords, regex=regex,
+                    parentMethod=parentMethod,
                 )
                 matchedKeywords.extend(first_matched)
 
             if secondMethodKeywords is not None:
                 # Check if arguments of the second call match any keywords.
                 second_matched = self.getMatchedKeywords(
-                    secondCall, secondMethodKeywords, regex=regex
+                    secondCall, secondMethodKeywords, regex=regex,
+                    parentMethod=parentMethod,
                 )
                 matchedKeywords.extend(second_matched)
 
@@ -338,6 +472,7 @@ class Quark:
                 first_method_keywords,
                 second_method_keywords,
                 regex,
+                parentMethod=parent_method,
             )
 
             found = next(results, None) is not None
@@ -373,22 +508,43 @@ class Quark:
 
         return state
 
-    @staticmethod
     def getMatchedKeywords(
-        methodCall: MethodCall, keywords: Sequence, regex: bool
+        self, methodCall: MethodCall, keywords: Sequence, regex: bool,
+        parentMethod=None,
     ) -> List[str]:
         """Get matched keywords from the parameters of a method call.
 
-        :param method_call: the method call to be checked
+        :param methodCall: the method call to be checked
         :param keywords: keywords to be matched
         :param regex: whether to treat keywords as regular expressions
-        :yield: a list of matched keywords
+        :param parentMethod: the method that contains methodCall; used by the
+            dynamic resolver to scan callers when the encryption function is
+            invoked in a higher frame (optional).
+        :return: a list of matched keywords
         """
         matchedStrSet = set()
         primitiveValues = {
             str(primitive.value)
             for primitive in iteratePriorPrimitives(methodCall)
         }
+
+        # Phase 5 dynamic fallback: run DexTrace when static primitives are
+        # absent or all empty strings (Primitive('') represents unknown
+        # parameter values in the value graph — not useful for keyword matching).
+        has_meaningful_primitives = any(pv for pv in primitiveValues if pv)
+        if not has_meaningful_primitives and self._dynamic_resolve and _DEXTRACE_AVAILABLE:
+            apk_path = self.apkinfo.apk_filepath
+            log.debug(
+                "dynamic_resolve: no meaningful static primitives for %s, trying DexTrace",
+                getattr(methodCall, "method", methodCall),
+            )
+            for resolved in _resolveStringCalls(
+                methodCall,
+                apk_path,
+                apkinfo=self.apkinfo,
+                parentMethod=parentMethod,
+            ):
+                primitiveValues.add(resolved)
 
         if not regex:
             return [

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,6 @@ setuptools.setup(
     install_requires=required_requirements,
     extras_require={
         "QuarkAgent": quarkAgentRequirements,
+        "dynamic": ["dextrace"],
     },
 )


### PR DESCRIPTION
Adds opt-in dynamic string resolution that runs encrypted string methods at analysis time using DexTrace, recovering plaintext for Phase 5 keyword matching.

**Verified:** bianlian APK — confidence 80% (static) → 100% (--dynamic-resolve)

> ⚠️ **Merge dependency:** DexTrace must be merged and published to PyPI before this PR can be merged. The \`pip install quark-engine[dynamic]\` extra requires \`dextrace\` to be available on PyPI. See: https://github.com/ev-flow/DexTrace/pull/2

**Key Changes:**
- [quark.py](https://github.com/haeter525/quark-engine/blob/feat/phase5-dynamic-resolution/quark/core/quark.py): add `_resolveStringCalls()` two-phase dynamic resolver, `_dextrace_cached()` LRU cache, `dynamic_resolve=False` param on `Quark.__init__`
- [cli.py](https://github.com/haeter525/quark-engine/blob/feat/phase5-dynamic-resolution/quark/cli.py): add `--dynamic-resolve` flag wired to `Quark()`
- [setup.py](https://github.com/haeter525/quark-engine/blob/feat/phase5-dynamic-resolution/setup.py): add `extras_require["dynamic"] = ["dextrace"]`

**Tests:**
- [x] `python -m pytest tests/core/test_quark.py` — 22 passed, 5 skipped (no regressions)
- [x] bianlian.apk `auto_click_comfirm_button_on_dialog.json` — 80% static → 100% with `--dynamic-resolve`